### PR TITLE
Removed unnecessary variable

### DIFF
--- a/users/api/views/user_logout.py
+++ b/users/api/views/user_logout.py
@@ -7,8 +7,7 @@ from reservation.decorators.request_method import check_request_method
 @csrf_exempt
 @check_request_method(method="GET")
 def user_logout(request):
-    current_user = request.user
-    if current_user.is_authenticated:
+    if request.user.is_authenticated:
         logout(request)
         return JsonResponse({"result": "You are now logged out!"}, status=200)
     else:


### PR DESCRIPTION
This PR updates-
* ```user_logout.py```
In this view, an unnecessary variable ```current_user``` was used which can be directly referenced using ```request.user```. Hence removed.

An attempt to improve #1! :slightly_smiling_face: 